### PR TITLE
Nested schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@size-limit/preset-small-lib": "^7.0.5",
     "@tsconfig/recommended": "^1.0.1",
+    "@types/object-path": "^0.11.1",
     "@types/ramda": "^0.27.61",
     "dts-cli": "^1.1.3",
     "size-limit": "^7.0.5",
@@ -78,5 +79,8 @@
   "bugs": {
     "url": "https://github.com/JoshuaAmaju/elderform/issues"
   },
-  "homepage": "https://github.com/JoshuaAmaju/elderform#readme"
+  "homepage": "https://github.com/JoshuaAmaju/elderform#readme",
+  "dependencies": {
+    "object-path": "^0.11.8"
+  }
 }

--- a/src/machine/index.ts
+++ b/src/machine/index.ts
@@ -102,6 +102,21 @@ const onChangeWithValidateActions = [
   ),
 ] as any;
 
+const validateActions = [
+  'removeError',
+  'setActorIdle',
+  send(
+    ({ values }: any, { id }: any) => ({
+      values,
+      type: 'VALIDATE',
+      value: recPath.get(values, id),
+    }),
+    {
+      to: (_, { id }) => id,
+    }
+  ),
+] as any;
+
 export const machine = <T, D, E, Es>() => {
   return createMachine<
     Context<T, D, E, Es>,
@@ -137,7 +152,7 @@ export const machine = <T, D, E, Es>() => {
           actions: onChangeActions,
         },
 
-        [EventTypes.Validate]: {
+        [EventTypes.ChangeWithValidate]: {
           target: 'idle',
           cond: 'hasSchema',
           actions: onChangeWithValidateActions,
@@ -253,7 +268,7 @@ export const machine = <T, D, E, Es>() => {
 
             [EventTypes.Validate]: {
               cond: 'hasSchema',
-              actions: onChangeWithValidateActions,
+              actions: validateActions,
             },
 
             [EventTypes.ChangeWithValidate]: {

--- a/src/machine/types.ts
+++ b/src/machine/types.ts
@@ -2,23 +2,6 @@ export type Schema<T = any> = {
   [K in keyof T]: Schema<T[K]> | Validator<T, T[K]>;
 };
 
-export type FlattenKeys<T extends object> = {
-  [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `${K}`>;
-}[keyof T & (string | number)];
-
-type RecursiveKeyOfInner<T extends object> = {
-  [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `.${K}`>;
-}[keyof T & (string | number)];
-
-type RecursiveKeyOfHandleValue<
-  TValue,
-  Text extends string
-> = TValue extends any[]
-  ? Text
-  : TValue extends object
-  ? Text | `${Text}${RecursiveKeyOfInner<TValue>}`
-  : Text;
-
 export type Validator<SchemaType = any, T = any> = (
   value: T,
   values: SchemaType

--- a/src/machine/types.ts
+++ b/src/machine/types.ts
@@ -1,4 +1,63 @@
-export type Schema<T = any> = { [K in keyof T]: Validator<T, T[K]> };
+export type Schema<T = any> = {
+  [K in keyof T]: Schema<T[K]> | Validator<T, T[K]>;
+};
+
+export type FlattenedSchema<T extends Schema = any> = {
+  [K in keyof T]: T[K] extends Schema<infer R> ? Schema<R> : T[K];
+};
+
+type Dotify<A, B> = `${string & A}.${string & B}`;
+
+export type RecursiveKeyOf<T extends object> = {
+  [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `${K}`>;
+}[keyof T & (string | number)];
+
+type RecursiveKeyOfInner<T extends object> = {
+  [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `.${K}`>;
+}[keyof T & (string | number)];
+
+type RecursiveKeyOfHandleValue<
+  TValue,
+  Text extends string
+> = TValue extends any[]
+  ? Text
+  : TValue extends object
+  ? Text | `${Text}${RecursiveKeyOfInner<TValue>}`
+  : Text;
+
+type N = {
+  name: string;
+  company: {
+    address: {
+      age: string;
+    };
+  };
+  age: string;
+};
+
+const n = {
+  name: () => '',
+  company: {
+    address: {
+      age: () => '',
+    },
+  },
+  age: () => '',
+};
+
+type M = Infer<typeof n>;
+
+type O<T extends object> = {
+  [K in
+    | keyof T
+    | Dotify<keyof T, { [P in keyof T[keyof T]]: any }>]: K extends keyof T
+    ? T[K]
+    : T[keyof T];
+};
+
+type Y = O<typeof n>;
+
+// let u: Y = ['name'];
 
 export type Validator<SchemaType = any, T = any> = (
   value: T,

--- a/src/machine/types.ts
+++ b/src/machine/types.ts
@@ -2,13 +2,7 @@ export type Schema<T = any> = {
   [K in keyof T]: Schema<T[K]> | Validator<T, T[K]>;
 };
 
-export type FlattenedSchema<T extends Schema = any> = {
-  [K in keyof T]: T[K] extends Schema<infer R> ? Schema<R> : T[K];
-};
-
-type Dotify<A, B> = `${string & A}.${string & B}`;
-
-export type RecursiveKeyOf<T extends object> = {
+export type FlattenKeys<T extends object> = {
   [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `${K}`>;
 }[keyof T & (string | number)];
 
@@ -24,40 +18,6 @@ type RecursiveKeyOfHandleValue<
   : TValue extends object
   ? Text | `${Text}${RecursiveKeyOfInner<TValue>}`
   : Text;
-
-type N = {
-  name: string;
-  company: {
-    address: {
-      age: string;
-    };
-  };
-  age: string;
-};
-
-const n = {
-  name: () => '',
-  company: {
-    address: {
-      age: () => '',
-    },
-  },
-  age: () => '',
-};
-
-type M = Infer<typeof n>;
-
-type O<T extends object> = {
-  [K in
-    | keyof T
-    | Dotify<keyof T, { [P in keyof T[keyof T]]: any }>]: K extends keyof T
-    ? T[K]
-    : T[keyof T];
-};
-
-type Y = O<typeof n>;
-
-// let u: Y = ['name'];
 
 export type Validator<SchemaType = any, T = any> = (
   value: T,

--- a/src/machine/utils.ts
+++ b/src/machine/utils.ts
@@ -1,0 +1,5 @@
+import { Schema } from './types';
+
+export const flatten = <T extends Schema>(schema: T) => {
+  let _schema = {} as T;
+};

--- a/src/machine/utils.ts
+++ b/src/machine/utils.ts
@@ -1,5 +1,75 @@
-import { Schema } from './types';
+import { Schema, Validator } from './types';
 
-export const flatten = <T extends Schema>(schema: T) => {
-  let _schema = {} as T;
+export type FlattenKeys<T> = {
+  [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `${K}`>;
+}[keyof T & (string | number)];
+
+type RecursiveKeyOfInner<T> = {
+  [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `.${K}`>;
+}[keyof T & (string | number)];
+
+type RecursiveKeyOfHandleValue<
+  TValue,
+  Text extends string
+> = TValue extends any[]
+  ? Text
+  : TValue extends object
+  ? Text | `${Text}${RecursiveKeyOfInner<TValue>}`
+  : Text;
+
+export type FlattenValues<T> = {
+  [K in keyof T & (string | number)]: RecursiveValueOfHandleValue<T[K]>;
+}[keyof T & (string | number)];
+
+type RecursiveValueOfInner<T> = {
+  [K in keyof T & (string | number)]: RecursiveValueOfHandleValue<T[K]>;
+}[keyof T & (string | number)];
+
+type RecursiveValueOfHandleValue<TValue> = TValue extends object
+  ? RecursiveValueOfInner<TValue>
+  : TValue;
+
+const a = {
+  b: {
+    c: 1,
+  },
+  d: {
+    e: {
+      f: '',
+    },
+  },
+};
+
+type M = typeof a;
+
+type N = FlattenKeys<M>;
+
+type T = FlattenValues<M>;
+
+const g = a as unknown as {
+  [K in N]: K extends keyof M
+    ? M[K] extends object
+      ? FlattenValues<M[K]>
+      : M[K]
+    : any;
+};
+
+export const flatten = <T>(
+  obj: T,
+  roots: (keyof T)[] = [],
+  sep = '.'
+): { [K in keyof T]: Validator } => {
+  return Object.keys(obj).reduce((accumulator, k) => {
+    const key = k as keyof T;
+    const value = obj[key];
+
+    return {
+      ...accumulator,
+      ...(Object.prototype.toString.call(value) === '[object Object]'
+        ? // keep working if value is an object
+          flatten(value as any, roots.concat([key]), sep)
+        : // include current prop and value and prefix prop with the roots
+          { [roots.concat([key]).join(sep)]: value }),
+    };
+  }, {} as any);
 };

--- a/src/machine/utils.ts
+++ b/src/machine/utils.ts
@@ -1,4 +1,4 @@
-import { Schema, Validator } from './types';
+import { Validator } from './types';
 
 export type FlattenKeys<T> = {
   [K in keyof T & (string | number)]: RecursiveKeyOfHandleValue<T[K], `${K}`>;
@@ -28,31 +28,6 @@ type RecursiveValueOfInner<T> = {
 type RecursiveValueOfHandleValue<TValue> = TValue extends object
   ? RecursiveValueOfInner<TValue>
   : TValue;
-
-const a = {
-  b: {
-    c: 1,
-  },
-  d: {
-    e: {
-      f: '',
-    },
-  },
-};
-
-type M = typeof a;
-
-type N = FlattenKeys<M>;
-
-type T = FlattenValues<M>;
-
-const g = a as unknown as {
-  [K in N]: K extends keyof M
-    ? M[K] extends object
-      ? FlattenValues<M[K]>
-      : M[K]
-    : any;
-};
 
 export const flatten = <T>(
   obj: T,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -41,3 +41,5 @@ export const retry = <T, E = any>(
 };
 
 export const object = <T, S = Schema<T>>(schema: S): S => schema;
+
+export const array = <T, S = Schema<T>>(schema: S): S => schema;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -41,5 +41,3 @@ export const retry = <T, E = any>(
 };
 
 export const object = <T, S = Schema<T>>(schema: S): S => schema;
-
-export const array = <T, S = Schema<T>>(schema: S): S => schema;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -502,10 +502,12 @@ describe('nested schemas', () => {
     });
   });
 
-  it('should access field state using dot notation', (done) => {
+  it('should access field state and error using dot notation', (done) => {
     const dotKey = 'address.line' as keyof Form;
 
     service?.onTransition(({ event, context }) => {
+      expect(context.errors.has(dotKey)).toBe(false);
+
       switch (event.type) {
         case 'VALIDATING':
           expect(context.states[dotKey]).toBe('validating');

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -463,6 +463,11 @@ describe('nested schemas', () => {
     ).start();
   });
 
+  afterEach(() => {
+    service?.stop();
+    service = null;
+  });
+
   it('should support nested values', (done) => {
     service?.onTransition((state) => {
       const { values } = state.context;
@@ -495,5 +500,28 @@ describe('nested schemas', () => {
       id: 'address.line' as any,
       value: 'No 15',
     });
+  });
+
+  it('should access field state using dot notation', (done) => {
+    const dotKey = 'address.line' as keyof Form;
+
+    service?.onTransition(({ event, context }) => {
+      switch (event.type) {
+        case 'VALIDATING':
+          expect(context.states[dotKey]).toBe('validating');
+          break;
+
+        case 'SUCCESS':
+          expect(context.states[dotKey]).toBe('success');
+          done();
+          break;
+
+        default:
+          expect(context.states[dotKey]).toBe('idle');
+          break;
+      }
+    });
+
+    service?.send({ id: dotKey, type: EventTypes.Validate });
   });
 });


### PR DESCRIPTION
Add support for nested schema of infinite depth. And accessing of nested fields using a dot notation e.g `{a: {b: {c: {1}}}, d: {e: 2}}` will be `a.b.c` and `d.e`